### PR TITLE
Trunc

### DIFF
--- a/include/sprout/math/trunc.hpp
+++ b/include/sprout/math/trunc.hpp
@@ -34,28 +34,32 @@ namespace sprout {
 				return __builtin_truncl(x);
 			}
 #endif
-		}	// namespace detail
+        }	// namespace detail
 		//
 		// trunc
 		//
 		template<
-			typename FloatType,
-			typename sprout::enabler_if<std::is_floating_point<FloatType>::value>::type = sprout::enabler
+            typename T,
+            typename sprout::enabler_if<
+                std::is_floating_point< T >::value
+                >::type = sprout::enabler
 		>
-		inline SPROUT_CONSTEXPR FloatType
-		trunc(FloatType x) {
-			return sprout::math::isnan(x) ? x
-				: x == sprout::numeric_limits<FloatType>::infinity() ? sprout::numeric_limits<FloatType>::infinity()
-				: x == -sprout::numeric_limits<FloatType>::infinity() ? -sprout::numeric_limits<FloatType>::infinity()
+        inline SPROUT_CONSTEXPR T
+        trunc(T x) {
+            return sprout::math::isnan(x) ? x
+                : x ==  sprout::numeric_limits< T >::infinity() ?  sprout::numeric_limits< T >::infinity()
+                : x == -sprout::numeric_limits< T >::infinity() ? -sprout::numeric_limits< T >::infinity()
 #if SPROUT_USE_BUILTIN_CMATH_FUNCTION
-				: sprout::math::detail::builtin_trunc(x)
+                : sprout::math::detail::builtin_trunc(x)
 #else
-				: x == 0 ? x
-                : (static_cast<FloatType>(sprout::numeric_limits<std::uintmax_t>::max()) <  x ||
-                   static_cast<FloatType>(sprout::numeric_limits<std::uintmax_t>::max()) < -x)
-					? SPROUT_MATH_THROW_LARGE_FLOAT_ROUNDING(std::runtime_error("trunc: large float rounding."), x)
-				: x < 0 ? -static_cast<FloatType>(static_cast<std::uintmax_t>(-x))
-				: static_cast<FloatType>(static_cast<std::uintmax_t>(x))
+                : x == 0 ? x
+                : x > 0
+                ? ( x < static_cast< T >(sprout::numeric_limits< std::uintmax_t >::max())
+                   ? static_cast< T >(static_cast< std::uintmax_t >(x))
+                   : SPROUT_MATH_THROW_LARGE_FLOAT_ROUNDING(std::runtime_error("trunc: large float rounding."), x))
+                : (-x < static_cast<T>(sprout::numeric_limits< std::uintmax_t >::max())
+                   ? -static_cast< T >(static_cast< std::uintmax_t >(-x))
+                   : SPROUT_MATH_THROW_LARGE_FLOAT_ROUNDING(std::runtime_error("trunc: large float rounding."), x))
 #endif
 				;
 		}

--- a/libs/math/test/trunc.cpp
+++ b/libs/math/test/trunc.cpp
@@ -20,16 +20,23 @@ BOOST_AUTO_TEST_SUITE(libs_math_trunc)
 
 BOOST_AUTO_TEST_CASE(libs_math_trunc_float)
 {
-    constexpr auto x = (std::numeric_limits< uintmax_t >::max)();
+    const auto x = (std::numeric_limits< uintmax_t >::max)();
     const auto result = sprout::math::trunc(static_cast< float >(x));
-    BOOST_TEST(result != 0.);
+    BOOST_TEST(result == static_cast< float >(x));
 }
 
 BOOST_AUTO_TEST_CASE(libs_math_trunc_double)
 {
-    constexpr auto x = (std::numeric_limits< uintmax_t >::max)();
+    const auto x = (std::numeric_limits< uintmax_t >::max)();
     const auto result = sprout::math::trunc(static_cast< double >(x));
-    BOOST_TEST(result != 0.);
+    BOOST_TEST(result == static_cast< double >(x));
+}
+
+BOOST_AUTO_TEST_CASE(libs_math_trunc_long_double)
+{
+    const auto x = (std::numeric_limits< uintmax_t >::max)();
+    const auto result = sprout::math::trunc(static_cast< long double >(x));
+    BOOST_TEST(result == static_cast< long double >(x));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The short story is that truncation in `sprout::math::trunc` fails for `2^n` where `n` is the number of bits in the largest unsigned integer used to roundtrip the floating point through in order to drop the decimal part. This only happens for floating point representations which cannot accurately represent `2^n-1` and have to round to nearest because mantissa is too small (even though they actually can hold values larger than `2^n`).

The longer story is that a truncation should not be attempted for any floating point value that is larger or equal than `2^m` with `m` being the number of bits in the mantissa because they do not have space for decimal parts anyways. This means `23` for floats, `52` for doubles and at least `63` for long doubles, depending on the implementation.